### PR TITLE
feat: add tags to traces

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"github.com/devigned/apmz-sdk/apmz"
-	"github.com/devigned/apmz-sdk/apmz/contracts"
 
 	"github.com/devigned/apmz/pkg/format"
 )
@@ -27,7 +26,7 @@ type (
 
 	// APMer provides the behaviors needed to send events to Azure Application Insights
 	APMer interface {
-		TrackTrace(name string, severity contracts.SeverityLevel)
+		Track(telemetry apmz.Telemetry)
 		Channel() apmz.TelemetryChannel
 	}
 )


### PR DESCRIPTION
`apmz trace -n tagstest2 -l 0 -t key1=foo1 -t key2=bar2`

```
$ ./bin/apmz trace
Error: required flag(s) "name" not set
Usage:
  apmz trace [flags]

Flags:
  -h, --help                  help for trace
  -l, --level int             severity level for the event
  -n, --name string           trace event name
  -t, --tags stringToString   custom tags to be applied to the trace formatted as key=value (default [])

Global Flags:
      --api-key string   App Insights API key
      --config string    config file (default is $HOME/.pub.yaml)

required flag(s) "name" not set
```