### PR TITLE
feat: add metrics

### DIFF
--- a/cmd/batch/batch.go
+++ b/cmd/batch/batch.go
@@ -1,0 +1,38 @@
+package batch
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/devigned/apmz/pkg/service"
+	"github.com/devigned/apmz/pkg/xcobra"
+)
+
+type (
+	batchArgs struct {
+		FilePath string
+	}
+)
+
+// NewBatchCommand creates a new `apmz batch` command
+func NewBatchCommand(sl service.CommandServicer) (*cobra.Command, error) {
+	var oArgs batchArgs
+	cmd := &cobra.Command{
+		Use:   "batch",
+		Short: "upload a batch of telemetry to Application Insights",
+		Run: xcobra.RunWithCtx(func(ctx context.Context, cmd *cobra.Command, args []string) error {
+			_, err := sl.GetAPMer()
+			if err != nil {
+				sl.GetPrinter().ErrPrintf("unable to create App Insight client: %v", err)
+				return err
+			}
+
+			return nil
+		}),
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&oArgs.FilePath, "file-path", "f", "", "file path to json events -- if not specified, then stdin will be assumed")
+	return cmd, nil
+}

--- a/cmd/metric/metric.go
+++ b/cmd/metric/metric.go
@@ -43,8 +43,8 @@ func NewMetricCommand(sl service.CommandServicer) (*cobra.Command, error) {
 
 	f := cmd.Flags()
 	f.Float64VarP(&oArgs.Value, "value", "v", 0, "value of the metric as a float64")
-	f.StringVarP(&oArgs.Name, "name", "n", "", "trace event name")
-	f.StringToStringVarP(&oArgs.Tags, "tags", "t", map[string]string{}, "custom tags to be applied to the trace formatted as key=value")
+	f.StringVarP(&oArgs.Name, "name", "n", "", "metric name")
+	f.StringToStringVarP(&oArgs.Tags, "tags", "t", map[string]string{}, "custom tags to be applied to the metric formatted as key=value")
 	err := cmd.MarkFlagRequired("name")
 	return cmd, err
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,10 +53,15 @@ func newRootCommand() (*cobra.Command, error) {
 	var apmer service.APMer
 	registry := &service.Registry{
 		APMerFactory: func() (service.APMer, error) {
+			var err error
 			once.Do(func() {
+				if apiKey == "" {
+					err = errors.New("must provide api-key")
+					return
+				}
 				apmer = apmz.NewTelemetryClient(apiKey)
 			})
-			return apmer, nil
+			return apmer, err
 		},
 		PrinterFactory: func() format.Printer {
 			return &format.StdPrinter{

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -11,7 +11,7 @@ func TestNewRootCmd(t *testing.T) {
 	root, err := newRootCommand()
 	require.NoError(t, err)
 
-	expected := []string{"trace", "version"}
+	expected := []string{"trace", "metric", "version"}
 	actual := make([]string, len(root.Commands()))
 	for i, c := range root.Commands() {
 		actual[i] = c.Name()

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"sync"
+
 	"github.com/devigned/apmz-sdk/apmz"
 
 	"github.com/devigned/apmz/pkg/format"
@@ -9,6 +11,7 @@ import (
 type (
 	// Registry holds the factories and services needed for command execution
 	Registry struct {
+		doOnce         sync.Once
 		APMerFactory   func() (APMer, error)
 		PrinterFactory func() format.Printer
 	}

--- a/pkg/xcobra/exit_handler.go
+++ b/pkg/xcobra/exit_handler.go
@@ -6,7 +6,8 @@ import (
 	"os"
 )
 
-func exitWithCode(err error) {
+// ExitWithCode will exit the program with a error code if provided, else 1
+func ExitWithCode(err error) {
 	if e, ok := err.(ErrorWithCode); ok {
 		os.Exit(e.Code)
 	}

--- a/pkg/xcobra/nop_handler.go
+++ b/pkg/xcobra/nop_handler.go
@@ -2,6 +2,7 @@
 
 package xcobra
 
-func exitWithCode(err error) {
-	// nop
+// ExitWithCode is a noop
+func ExitWithCode(err error) {
+	// noop
 }


### PR DESCRIPTION
```
$ ./bin/apmz metric
Error: required flag(s) "name" not set
Usage:
  apmz metric [flags]

Flags:
  -h, --help                  help for metric
  -n, --name string           metric name
  -t, --tags stringToString   custom tags to be applied to the metric formatted as key=value (default [])
  -v, --value float           value of the metric as a float64

Global Flags:
      --api-key string   App Insights API key
      --config string    config file (default is $HOME/.pub.yaml)

required flag(s) "name" not set
```