### PR TITLE
feat: add correlation id to default tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,18 +16,18 @@ V = 0
 Q = $(if $(filter 1,$V),,@)
 
 .PHONY: all
-all: install-tools generate fmt lint vet tidy build
+all: build
 
 .PHONY: install-tools
 install-tools: ; $(info $(M) installing tools…)
 	$(Q) make -C ./tools
 
 .PHONY: build
-build: lint tidy ; $(info $(M) buiding ./bin/$(APP))
+build: generate lint tidy ; $(info $(M) buiding ./bin/$(APP))
 	$Q $(GO) build -ldflags "-X $(PACKAGE)/cmd.GitCommit=$(VERSION)" -o ./bin/$(APP)
 
 .PHONY: generate
-generate: ; $(info $(M) running generate…)
+generate: install-tools ; $(info $(M) running generate…)
 	$Q $(BINDATA) -o ./pkg/data/bindata.go -pkg data -nocompress ./data/...
 
 .PHONY: lint
@@ -53,7 +53,7 @@ build-debug: ; $(info $(M) buiding debug...)
 	$Q $(GO)  build -o ./bin/$(APP) -tags debug
 
 .PHONY: test-generate ; $(info $(M) running test-generate…)
-test-generate: ; $(info $(M) generating test data…)
+test-generate: install-tools ; $(info $(M) generating test data…)
 	$Q $(BINDATA) -o ./internal/test/bash/bindata.go -pkg bash_test -nocompress ./cmd/bash/testdata/...
 
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Available Commands:
   metric      send a metric (customMetrics) to Application Insights
   time        time related commands
   trace       send a trace event (traces) to Application Insights
+  uuid        generate a new uuid
   version     Print the git ref
 
 Flags:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/devigned/apmz/cmd/metric"
 	timecmd "github.com/devigned/apmz/cmd/time"
 	"github.com/devigned/apmz/cmd/trace"
+	"github.com/devigned/apmz/cmd/uuid"
 	"github.com/devigned/apmz/pkg/format"
 	"github.com/devigned/apmz/pkg/service"
 )
@@ -91,6 +92,7 @@ func newRootCommand() (*cobra.Command, error) {
 		batch.NewBatchCommand,
 		bash.NewBashCommand,
 		timecmd.NewTimeCommandGroup,
+		uuid.NewUUIDCommand,
 		func(locator service.CommandServicer) (*cobra.Command, error) {
 			return newVersionCommand(), nil
 		},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -11,7 +11,7 @@ func TestNewRootCmdNames(t *testing.T) {
 	root, err := newRootCommand()
 	require.NoError(t, err)
 
-	expected := []string{"trace", "metric", "batch", "version", "bash", "time"}
+	expected := []string{"trace", "metric", "batch", "version", "bash", "time", "uuid"}
 	actual := make([]string, len(root.Commands()))
 	for i, c := range root.Commands() {
 		actual[i] = c.Name()

--- a/cmd/time/diff.go
+++ b/cmd/time/diff.go
@@ -48,7 +48,7 @@ func newDiffUnixNanoCommand(sl service.CommandServicer) (*cobra.Command, error) 
 	f := cmd.Flags()
 	f.Int64VarP(&oArgs.A, "first", "a", 0, "first time in unixnano format")
 	f.Int64VarP(&oArgs.B, "second", "b", 0, "second time in unixnano format")
-	f.StringVarP(&oArgs.Format, "resolution", "r", "nano", "time resolution [nano, micro, ms, sec]")
+	f.StringVarP(&oArgs.Format, "resolution", "r", "sec", "time resolution [nano, micro, ms, sec]")
 
 	return cmd, nil
 }

--- a/cmd/uuid/uuid.go
+++ b/cmd/uuid/uuid.go
@@ -1,0 +1,27 @@
+package uuid
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/google/uuid"
+
+	"github.com/devigned/apmz/pkg/service"
+	"github.com/devigned/apmz/pkg/xcobra"
+)
+
+// NewUUIDCommand will create a new `apmz uuid` command
+func NewUUIDCommand(sl service.CommandServicer) (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   "uuid",
+		Short: "generate a new uuid",
+		Run: xcobra.RunWithCtx(func(ctx context.Context, cmd *cobra.Command, args []string) error {
+			id := uuid.New()
+			sl.GetPrinter().Printf("%s", id.String())
+			return nil
+		}),
+	}
+
+	return cmd, nil
+}

--- a/cmd/uuid/uuid_test.go
+++ b/cmd/uuid/uuid_test.go
@@ -1,0 +1,71 @@
+package uuid_test
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	gid "github.com/google/uuid"
+
+	"github.com/devigned/apmz/cmd/uuid"
+	mocks "github.com/devigned/apmz/internal/test"
+)
+
+func TestUUIDCommand(t *testing.T) {
+	cases := []struct {
+		name       string
+		setup      func(t *testing.T) *mocks.ServiceMock
+		assertions func(t *testing.T, cmd *cobra.Command)
+	}{
+		{
+			name: "CommandConstruction",
+			setup: func(t *testing.T) *mocks.ServiceMock {
+				return nil
+			},
+			assertions: func(t *testing.T, cmd *cobra.Command) {
+				assert.Equal(t, "uuid", cmd.Name())
+			},
+		},
+		{
+			name: "PrintsNewUUID",
+			setup: func(t *testing.T) *mocks.ServiceMock {
+				s := new(mocks.ServiceMock)
+				p := new(mocks.PrinterMock)
+				p.On("Printf", "%s", mock.MatchedBy(func(output []interface{}) bool {
+					require.Len(t, output, 1)
+					firstArg, ok := output[0].(string)
+					if !ok {
+						return false
+					}
+
+					_, err := gid.Parse(firstArg)
+					if err != nil {
+						return false
+					}
+
+					return true
+				}))
+				s.On("GetPrinter").Return(p)
+				return s
+			},
+			assertions: func(t *testing.T, cmd *cobra.Command) {
+				assert.NoError(t, cmd.Execute())
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			s := c.setup(t)
+			cmd, err := uuid.NewUUIDCommand(s)
+			assert.NoError(t, err)
+			assert.NotNil(t, cmd)
+			c.assertions(t, cmd)
+		})
+	}
+}

--- a/data/enabled_bash.gosh
+++ b/data/enabled_bash.gosh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
 __TMP_APMZ_BATCH_FILE="${__TMP_APMZ_BATCH_FILE:-$(mktemp /tmp/apmz.XXXXXX)}"
+__SCRIPT_SESSION_ID="${__SCRIPT_SESSION_ID:-$(apmz uuid)}"
 __SCRIPT_START_TIME=$(apmz time unixnano)
 __SCRIPT_NAME="${__SCRIPT_NAME:-{{.ScriptName}}}"
 __APP_INSIGHTS_KEY="${__APP_INSIGHTS_KEY:-{{.AppInsightsKey}}}"
 __DEFAULT_TAGS="${__DEFAULT_TAGS:-{{.DefaultTags}}}"
+__DEFAULT_TIME="${__DEFAULT_TIME:-sec}"
 
 # trace_err will log an error level trace event to the tmp batch file in $TMP_APMZ_BATCH_FILE
 #
@@ -42,7 +44,7 @@ time_metric() {
   start=$(apmz time unixnano)
   "$@"
   end=$(apmz time unixnano)
-  diff=$(apmz time diff -a "${start}" -b "${end}")
+  diff=$(apmz time diff -a "${start}" -b "${end}" -r "${__DEFAULT_TIME}")
   tags=$(append_default_tags)
   if [[ -z "${tags}" ]]; then
     apmz metric -n "${name}" -v "${diff}" -o >>"${__TMP_APMZ_BATCH_FILE}"
@@ -63,7 +65,7 @@ time_metric_with_tags() {
   start=$(apmz time unixnano)
   "$@"
   end=$(apmz time unixnano)
-  diff=$(apmz time diff -a "${start}" -b "${end}")
+  diff=$(apmz time diff -a "${start}" -b "${end}" -r "${__DEFAULT_TIME}")
   tags=$(append_default_tags "${tags}")
   if [[ -z "${tags}" ]]; then
     apmz metric -n "${name}" -v "${diff}" -o >>"${__TMP_APMZ_BATCH_FILE}"
@@ -104,7 +106,7 @@ exitAndFlush() {
   fi
 
   script_end=$(apmz time unixnano)
-  duration=$(apmz time diff -a "$__SCRIPT_START_TIME" -b "$script_end")
+  duration=$(apmz time diff -a "$__SCRIPT_START_TIME" -b "$script_end"  -r "${__DEFAULT_TIME}")
   if [[ -z "${__DEFAULT_TAGS}" ]]; then
     apmz metric -n "$__SCRIPT_NAME-duration" -v "${duration}" -o >>"${__TMP_APMZ_BATCH_FILE}"
   else
@@ -121,3 +123,5 @@ exitAndFlush() {
 }
 
 trap exitAndFlush EXIT
+
+__DEFAULT_TAGS=$(join_tags "${__DEFAULT_TAGS}" "correlation_id=${__SCRIPT_SESSION_ID}" )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/devigned/apmz-sdk v0.0.4
 	github.com/devigned/tab v0.0.1
 	github.com/devigned/tab/opencensus v0.1.2
+	github.com/google/uuid v1.1.1
 	github.com/joho/godotenv v1.3.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=

--- a/pkg/data/bindata.go
+++ b/pkg/data/bindata.go
@@ -79,7 +79,7 @@ append_default_tags() {
   return
 }
 
-default_apmz_tags() {
+join_tags() {
   return
 }`)
 
@@ -93,7 +93,7 @@ func dataDisabled_bashGosh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "data/disabled_bash.gosh", size: 236, mode: os.FileMode(420), modTime: time.Unix(1578612908, 0)}
+	info := bindataFileInfo{name: "data/disabled_bash.gosh", size: 228, mode: os.FileMode(420), modTime: time.Unix(1578931050, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -101,10 +101,12 @@ func dataDisabled_bashGosh() (*asset, error) {
 var _dataEnabled_bashGosh = []byte(`#!/usr/bin/env bash
 
 __TMP_APMZ_BATCH_FILE="${__TMP_APMZ_BATCH_FILE:-$(mktemp /tmp/apmz.XXXXXX)}"
+__SCRIPT_SESSION_ID="${__SCRIPT_SESSION_ID:-$(apmz uuid)}"
 __SCRIPT_START_TIME=$(apmz time unixnano)
 __SCRIPT_NAME="${__SCRIPT_NAME:-{{.ScriptName}}}"
 __APP_INSIGHTS_KEY="${__APP_INSIGHTS_KEY:-{{.AppInsightsKey}}}"
 __DEFAULT_TAGS="${__DEFAULT_TAGS:-{{.DefaultTags}}}"
+__DEFAULT_TIME="${__DEFAULT_TIME:-sec}"
 
 # trace_err will log an error level trace event to the tmp batch file in $TMP_APMZ_BATCH_FILE
 #
@@ -142,7 +144,7 @@ time_metric() {
   start=$(apmz time unixnano)
   "$@"
   end=$(apmz time unixnano)
-  diff=$(apmz time diff -a "${start}" -b "${end}")
+  diff=$(apmz time diff -a "${start}" -b "${end}" -r "${__DEFAULT_TIME}")
   tags=$(append_default_tags)
   if [[ -z "${tags}" ]]; then
     apmz metric -n "${name}" -v "${diff}" -o >>"${__TMP_APMZ_BATCH_FILE}"
@@ -163,7 +165,7 @@ time_metric_with_tags() {
   start=$(apmz time unixnano)
   "$@"
   end=$(apmz time unixnano)
-  diff=$(apmz time diff -a "${start}" -b "${end}")
+  diff=$(apmz time diff -a "${start}" -b "${end}" -r "${__DEFAULT_TIME}")
   tags=$(append_default_tags "${tags}")
   if [[ -z "${tags}" ]]; then
     apmz metric -n "${name}" -v "${diff}" -o >>"${__TMP_APMZ_BATCH_FILE}"
@@ -177,12 +179,20 @@ time_metric_with_tags() {
 # should be invoked in the following way: `+"`"+`append_default_tags "${tags}"`+"`"+`
 append_default_tags() {
   local tags=$1
-  if [[ -n "${__DEFAULT_TAGS}" && -n "${tags}" ]]; then
-    echo "${tags},${__DEFAULT_TAGS}"
-  elif [[ -z "${tags}" ]]; then
-    echo "${__DEFAULT_TAGS}"
+  join_tags "$1" "${__DEFAULT_TAGS}"
+}
+
+# append_default_tags will append default_apmz_tags to the input tags string
+#
+# should be invoked in the following way: `+"`"+`join_tags "${tags_left}" "${tags_right}"`+"`"+`
+join_tags() {
+  local left=$1 right=$2
+  if [[ -n "${left}" && -n "${right}" ]]; then
+    echo "${left},${right}"
+  elif [[ -z "${left}" ]]; then
+    echo "${right}"
   else
-    echo "${tags}"
+    echo "${left}"
   fi
 }
 
@@ -196,7 +206,7 @@ exitAndFlush() {
   fi
 
   script_end=$(apmz time unixnano)
-  duration=$(apmz time diff -a "$__SCRIPT_START_TIME" -b "$script_end")
+  duration=$(apmz time diff -a "$__SCRIPT_START_TIME" -b "$script_end"  -r "${__DEFAULT_TIME}")
   if [[ -z "${__DEFAULT_TAGS}" ]]; then
     apmz metric -n "$__SCRIPT_NAME-duration" -v "${duration}" -o >>"${__TMP_APMZ_BATCH_FILE}"
   else
@@ -213,7 +223,8 @@ exitAndFlush() {
 }
 
 trap exitAndFlush EXIT
-`)
+
+__DEFAULT_TAGS=$(join_tags "${__DEFAULT_TAGS}" "correlation_id=${__SCRIPT_SESSION_ID}" )`)
 
 func dataEnabled_bashGoshBytes() ([]byte, error) {
 	return _dataEnabled_bashGosh, nil
@@ -225,7 +236,7 @@ func dataEnabled_bashGosh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "data/enabled_bash.gosh", size: 3717, mode: os.FileMode(420), modTime: time.Unix(1578806788, 0)}
+	info := bindataFileInfo{name: "data/enabled_bash.gosh", size: 4191, mode: os.FileMode(420), modTime: time.Unix(1578958887, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
- add correlation_id to default tags which is created upon script eval
- change default time resolution to seconds rather than nano
- add `join_tags` function