### PR TITLE
feat: multiple app insights keys

### DIFF
--- a/cmd/bash/bash.go
+++ b/cmd/bash/bash.go
@@ -39,10 +39,8 @@ func NewBashCommand(sl service.CommandServicer) (*cobra.Command, error) {
 				}
 			} else {
 				// enabled, so we need to have the AppInsightsKey set
-				if sl.GetKey() == "" {
-					warning := `Warning: apmz event collection is enabled, but --api-key is not specified. You must override
-the __APP_INSIGHTS_KEY env var or events will not be set to Application Insights on script exit.
-`
+				if sl.GetKeys() == nil || len(sl.GetKeys()) == 0 {
+					warning := "Warning: apmz event collection is enabled, but --api-keys is not specified. You must override the __APP_INSIGHTS_KEY env var or events will not be set to Application Insights on script exit.\n"
 					sl.GetPrinter().ErrPrintf(warning)
 				}
 			}
@@ -54,13 +52,16 @@ the __APP_INSIGHTS_KEY env var or events will not be set to Application Insights
 
 			tags := strings.Join(kvs, ",")
 			input := struct {
-				ScriptName     string
-				DefaultTags    string
-				AppInsightsKey string
+				ScriptName      string
+				DefaultTags     string
+				AppInsightsKeys string
 			}{
-				ScriptName:     oArgs.ScriptName,
-				DefaultTags:    tags,
-				AppInsightsKey: sl.GetKey(),
+				ScriptName:  oArgs.ScriptName,
+				DefaultTags: tags,
+			}
+
+			if sl.GetKeys() != nil {
+				input.AppInsightsKeys = strings.Join(sl.GetKeys(), ",")
 			}
 
 			tmpl, err := template.New("script").Parse(string(script))

--- a/cmd/bash/bash_test.go
+++ b/cmd/bash/bash_test.go
@@ -97,6 +97,6 @@ func TestNewBashCommand(t *testing.T) {
 
 func serviceWithKey() *mocks.ServiceMock {
 	s := new(mocks.ServiceMock)
-	s.On("GetKey").Return("foo")
+	s.On("GetKeys").Return([]string{"foo"})
 	return s
 }

--- a/cmd/batch/batch.go
+++ b/cmd/batch/batch.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -31,7 +30,7 @@ func NewBatchCommand(sl service.CommandServicer) (*cobra.Command, error) {
 		Run: xcobra.RunWithCtx(func(ctx context.Context, cmd *cobra.Command, args []string) error {
 			apmzer, err := sl.GetAPMer()
 			if err != nil {
-				sl.GetPrinter().ErrPrintf("unable to create App Insight client: %v", err)
+				sl.GetPrinter().ErrPrintf("unable to create App Insight client: %v\n", err)
 				return err
 			}
 
@@ -39,7 +38,7 @@ func NewBatchCommand(sl service.CommandServicer) (*cobra.Command, error) {
 			if oArgs.FilePath != "" {
 				bits, err := ioutil.ReadFile(oArgs.FilePath)
 				if err != nil {
-					sl.GetPrinter().ErrPrintf("unable to read file: %v", err)
+					sl.GetPrinter().ErrPrintf("unable to read file: %v\n", err)
 					return err
 				}
 				reader = bytes.NewReader(bits)
@@ -47,7 +46,7 @@ func NewBatchCommand(sl service.CommandServicer) (*cobra.Command, error) {
 
 			eventsBits, err := ioutil.ReadAll(reader)
 			if err != nil {
-				sl.GetPrinter().ErrPrintf("unable to read: %v", err)
+				sl.GetPrinter().ErrPrintf("unable to read: %v\n", err)
 				return err
 			}
 
@@ -69,7 +68,8 @@ func NewBatchCommand(sl service.CommandServicer) (*cobra.Command, error) {
 				sent++
 			}
 
-			return sl.GetPrinter().Print(struct{ Result string }{Result: fmt.Sprintf("sent %d events", sent)})
+			sl.GetPrinter().ErrPrintf("sent %d events\n", sent)
+			return nil
 		}),
 	}
 

--- a/cmd/metric/metric.go
+++ b/cmd/metric/metric.go
@@ -27,7 +27,7 @@ func NewMetricCommand(sl service.CommandServicer) (*cobra.Command, error) {
 		Run: xcobra.RunWithCtx(func(ctx context.Context, cmd *cobra.Command, args []string) error {
 			apmer, err := sl.GetAPMer()
 			if err != nil {
-				sl.GetPrinter().ErrPrintf("unable to create App Insight client: %v", err)
+				sl.GetPrinter().ErrPrintf("unable to create App Insight client: %v\n", err)
 				return err
 			}
 

--- a/cmd/time/diff.go
+++ b/cmd/time/diff.go
@@ -39,7 +39,7 @@ func newDiffUnixNanoCommand(sl service.CommandServicer) (*cobra.Command, error) 
 			case "sec":
 				sl.GetPrinter().Printf("%f", math.Abs(elapsed.Seconds()))
 			default:
-				sl.GetPrinter().ErrPrintf("unknown time resolution %q", oArgs.Format)
+				sl.GetPrinter().ErrPrintf("unknown time resolution %q\n", oArgs.Format)
 			}
 			return nil
 		}),

--- a/cmd/trace/trace.go
+++ b/cmd/trace/trace.go
@@ -34,7 +34,7 @@ func NewTraceCommand(sl service.CommandServicer) (*cobra.Command, error) {
 
 			apmer, err := sl.GetAPMer()
 			if err != nil {
-				sl.GetPrinter().ErrPrintf("unable to create App Insight client: %v", err)
+				sl.GetPrinter().ErrPrintf("unable to create App Insight client: %v\n", err)
 				return err
 			}
 

--- a/data/enabled_bash.gosh
+++ b/data/enabled_bash.gosh
@@ -4,7 +4,7 @@ __TMP_APMZ_BATCH_FILE="${__TMP_APMZ_BATCH_FILE:-$(mktemp /tmp/apmz.XXXXXX)}"
 __SCRIPT_SESSION_ID="${__SCRIPT_SESSION_ID:-$(apmz uuid)}"
 __SCRIPT_START_TIME=$(apmz time unixnano)
 __SCRIPT_NAME="${__SCRIPT_NAME:-{{.ScriptName}}}"
-__APP_INSIGHTS_KEY="${__APP_INSIGHTS_KEY:-{{.AppInsightsKey}}}"
+__APP_INSIGHTS_KEYS="${__APP_INSIGHTS_KEYS:-{{.AppInsightsKeys}}}"
 __DEFAULT_TAGS="${__DEFAULT_TAGS:-{{.DefaultTags}}}"
 __DEFAULT_TIME="${__DEFAULT_TIME:-sec}"
 
@@ -113,8 +113,8 @@ exitAndFlush() {
     apmz metric -n "$__SCRIPT_NAME-duration" -v "${duration}" -t "${__DEFAULT_TAGS}" -o >>"${__TMP_APMZ_BATCH_FILE}"
   fi
 
-  if [[ -n "${__APP_INSIGHTS_KEY}" && -z "${__DRY_RUN}" ]]; then
-    apmz batch -f "${__TMP_APMZ_BATCH_FILE}" --api-key "${__APP_INSIGHTS_KEY}"
+  if [[ -n "${__APP_INSIGHTS_KEYS}" && -z "${__DRY_RUN}" ]]; then
+    apmz batch -f "${__TMP_APMZ_BATCH_FILE}" --api-keys "${__APP_INSIGHTS_KEYS}"
   fi
 
   if [[ -z "${__PRESERVE_TMP_FILE}" ]]; then

--- a/internal/test/bash/bindata.go
+++ b/internal/test/bash/bindata.go
@@ -71,7 +71,7 @@ func cmdBashTestdataBase_scriptGosh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "cmd/bash/testdata/base_script.gosh", size: 95, mode: os.FileMode(420), modTime: time.Unix(1578809708, 0)}
+	info := bindataFileInfo{name: "cmd/bash/testdata/base_script.gosh", size: 95, mode: os.FileMode(420), modTime: time.Unix(1579299060, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/internal/test/mocks.go
+++ b/internal/test/mocks.go
@@ -41,9 +41,9 @@ func (sm *ServiceMock) GetPrinter() format.Printer {
 	return args.Get(0).(format.Printer)
 }
 
-func (sm *ServiceMock) GetKey() string {
+func (sm *ServiceMock) GetKeys() []string {
 	args := sm.Called()
-	return args.String(0)
+	return args.Get(0).([]string)
 }
 
 func (sm *ServiceMock) GetMetadater() (service.Metadater, error) {

--- a/pkg/data/bindata.go
+++ b/pkg/data/bindata.go
@@ -104,7 +104,7 @@ __TMP_APMZ_BATCH_FILE="${__TMP_APMZ_BATCH_FILE:-$(mktemp /tmp/apmz.XXXXXX)}"
 __SCRIPT_SESSION_ID="${__SCRIPT_SESSION_ID:-$(apmz uuid)}"
 __SCRIPT_START_TIME=$(apmz time unixnano)
 __SCRIPT_NAME="${__SCRIPT_NAME:-{{.ScriptName}}}"
-__APP_INSIGHTS_KEY="${__APP_INSIGHTS_KEY:-{{.AppInsightsKey}}}"
+__APP_INSIGHTS_KEYS="${__APP_INSIGHTS_KEYS:-{{.AppInsightsKeys}}}"
 __DEFAULT_TAGS="${__DEFAULT_TAGS:-{{.DefaultTags}}}"
 __DEFAULT_TIME="${__DEFAULT_TIME:-sec}"
 
@@ -213,8 +213,8 @@ exitAndFlush() {
     apmz metric -n "$__SCRIPT_NAME-duration" -v "${duration}" -t "${__DEFAULT_TAGS}" -o >>"${__TMP_APMZ_BATCH_FILE}"
   fi
 
-  if [[ -n "${__APP_INSIGHTS_KEY}" && -z "${__DRY_RUN}" ]]; then
-    apmz batch -f "${__TMP_APMZ_BATCH_FILE}" --api-key "${__APP_INSIGHTS_KEY}"
+  if [[ -n "${__APP_INSIGHTS_KEYS}" && -z "${__DRY_RUN}" ]]; then
+    apmz batch -f "${__TMP_APMZ_BATCH_FILE}" --api-keys "${__APP_INSIGHTS_KEYS}"
   fi
 
   if [[ -z "${__PRESERVE_TMP_FILE}" ]]; then
@@ -236,7 +236,7 @@ func dataEnabled_bashGosh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "data/enabled_bash.gosh", size: 4191, mode: os.FileMode(420), modTime: time.Unix(1578961032, 0)}
+	info := bindataFileInfo{name: "data/enabled_bash.gosh", size: 4197, mode: os.FileMode(420), modTime: time.Unix(1579297730, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Add support for sending events to multiple Application Insights collectors via `--api-keys` rather than `--api-key`.